### PR TITLE
Feat remove outliers

### DIFF
--- a/R/mod_boot_results.R
+++ b/R/mod_boot_results.R
@@ -19,7 +19,7 @@ boot_results_server = function(id, values, i) {
     # Histogram ----------------------------------------------------------------
     output$results_hist = renderPlotly({
       boot_reps = values[[paste0("boot_reps", i)]]
-      
+      print(boot_reps)
       # Compute density
       density = density(boot_reps$estimate)
       

--- a/R/mod_boot_results.R
+++ b/R/mod_boot_results.R
@@ -14,15 +14,17 @@ boot_results_ui = function(id) {
   )
 }
 
-boot_results_server = function(id, values) {
+boot_results_server = function(id, values, i) {
   moduleServer(id, function(input, output, session) {
     # Histogram ----------------------------------------------------------------
     output$results_hist = renderPlotly({
+      boot_reps = values[[paste0("boot_reps", i)]]
+      
       # Compute density
-      density = density(values$boot_reps0$estimate)
+      density = density(boot_reps$estimate)
       
       # Compute pivot confidence interval bounds
-      ci_values = make_pivot_ci(values$boot_reps0, "estimate", input$ci_alpha)
+      ci_values = make_pivot_ci(boot_reps, "estimate", input$ci_alpha)
       values$ci = tibble(
         estimate = ci_values[1],
         lower = ci_values[2],
@@ -53,7 +55,7 @@ boot_results_server = function(id, values) {
         add_trace(
           name = "Histogram",
           type = "histogram",
-          data = values$boot_reps0,
+          data = boot_reps,
           x = ~estimate,
           hovertemplate = "Bin range: %{x}<br>Estimates: %{y}<extra></extra>"
         ) %>%
@@ -77,8 +79,11 @@ boot_results_server = function(id, values) {
     
     # Numeric results ----------------------------------------------------------
     output$results_summary = renderUI({
+      boot_reps = values[[paste0("boot_reps", i)]]
+      user_file = values[[paste0("user_file", i)]]
+      boot_stat = values[[paste0("boot_stat", i)]]
       # Maximum decimals in passed data for rounding purposes
-      decimals = values$user_file %>%
+      decimals = user_file %>%
         pull(as.name(values$param_variable)) %>%
         count_decimals() %>%
         max()
@@ -87,10 +92,10 @@ boot_results_server = function(id, values) {
         # Summary statistics ---------------------------------------------------
         column(width = 6, align = "center",
           h3("Mean Estimate"),
-          h4(round(values$boot_stat0, decimals + 1)),
+          h4(round(boot_stat, decimals + 1)),
           
           h3("Standard Error"),
-          h4(round(sd(values$boot_reps0$estimate), decimals + 1))
+          h4(round(sd(boot_reps$estimate), decimals + 1))
         ),
         # Confidence interval --------------------------------------------------
         column(width = 6, align = "center",
@@ -103,7 +108,7 @@ boot_results_server = function(id, values) {
           ),
           
           h3("Skewness"),
-          h4(round(skewness(values$boot_reps0$estimate), decimals + 3))
+          h4(round(skewness(boot_reps$estimate), decimals + 3))
         )
       )
     })

--- a/server.R
+++ b/server.R
@@ -26,15 +26,15 @@ shinyServer(function(input, output, session) {
     
     # Resample
     boot_results = do_bootstrap(
-      values$user_file,
-      B = input$param_B,
-      fn = input$param_statistic,
-      variable = input$param_variable)
+      values$user_file0,
+      B = values$param_B,
+      fn = values$param_statistic,
+      variable = values$param_variable)
     values$boot_reps0 = boot_results$reps
     values$boot_stat0 = boot_results$stat
     
     # Navigate to results
-    updateTabsetPanel(session, "wizard", selected = "boot_results")
+    updateTabsetPanel(session, "wizard", selected = "prelim_results")
     remove_modal_spinner()
   })
   
@@ -67,7 +67,34 @@ shinyServer(function(input, output, session) {
   
   # Outlier detection page -----------------------------------------------------
   observeEvent(input$outliers_next, {
+    if (is.null(input$outliers_rows_selected)) {
+      # Do nothing if no outliers are selected
+      values$user_file1 = values$user_file0
+    }
+    else {
+      # Show busy dialog
+      show_modal_spinner(spin = "swapping-squares", text = "Updating...")
+      
+      # Remove selected outliers
+      remove_ids = values$outlier_table %>%
+        slice(input$outliers_rows_selected) %>%
+        pull(row_id)
+      values$user_file1 = filter(values$user_file0, !row_id %in% remove_ids)
+      
+      # Bootstrap outlier-removed data
+      boot_results = do_bootstrap(
+        values$user_file1,
+        B = values$param_B,
+        fn = values$param_statistic,
+        variable = values$param_variable
+      )
+      values$boot_reps1 = boot_results$reps
+      values$boot_stat1 = boot_results$stat
+    }
     
+    # Navigate to results
+    updateTabsetPanel(session, "wizard", selected = "outlier_results")
+    remove_modal_spinner()
   })
   
   observeEvent(input$outliers_previous, {
@@ -84,7 +111,7 @@ shinyServer(function(input, output, session) {
     } else {
       # Add row IDs
       df = readr::read_csv(path, col_types=cols())
-      values$user_file = mutate(df, row_id = 1:nrow(df))
+      values$user_file0 = mutate(df, row_id = 1:nrow(df))
     }
   })
   
@@ -92,13 +119,13 @@ shinyServer(function(input, output, session) {
   # Data preview ---------------------------------------------------------------
   output$data_preview = DT::renderDataTable({
     # Don't display table until something is loaded
-    if (is.null(values$user_file)) return(NULL) else return(values$user_file)
+    if (is.null(values$user_file0)) return(NULL) else return(values$user_file0)
   }, options=list(scrollX=TRUE))
   
   # Data page conditional action button ----------------------------------------
   output$data_upload_next = renderUI({
     ui = NULL
-    if (!is.null(values$user_file)) {
+    if (!is.null(values$user_file0)) {
       ui = fluidRow(
         column(width = 12,
           hr(),
@@ -112,7 +139,7 @@ shinyServer(function(input, output, session) {
   # Statistic selection --------------------------------------------------------
   output$select_variable = renderUI({
     # Get variables from loaded data, if present
-    if (!is.null(values$user_file)) choices = colnames(values$user_file)
+    if (!is.null(values$user_file0)) choices = colnames(values$user_file0)
     else choices = NULL
     
     # Generate input
@@ -120,7 +147,8 @@ shinyServer(function(input, output, session) {
   })
   
   # Bootstrap results ==========================================================
-  boot_results_server("prelim", values)
+  boot_results_server("prelim", values, 0)
+  boot_results_server("outliers", values, 1)
   
   # Outlier detection ==========================================================
   # Jackknife-after-bootstrap plot ---------------------------------------------
@@ -219,7 +247,7 @@ shinyServer(function(input, output, session) {
   # Outlier display ------------------------------------------------------------
   output$outliers = DT::renderDataTable({
     if (length(values$outliers > 0)){
-      values$outlier_table = values$user_file %>%
+      values$outlier_table = values$user_file0 %>%
         filter(row_id %in% values$outliers)
     } else NULL
   }, selection = list(selected = 1:length(values$outliers)),

--- a/server.R
+++ b/server.R
@@ -70,6 +70,8 @@ shinyServer(function(input, output, session) {
     if (is.null(input$outliers_rows_selected)) {
       # Do nothing if no outliers are selected
       values$user_file1 = values$user_file0
+      values$boot_reps1 = values$boot_reps0
+      values$boot_stat1 = values$boot_stat0
     }
     else {
       # Show busy dialog

--- a/server.R
+++ b/server.R
@@ -72,6 +72,9 @@ shinyServer(function(input, output, session) {
       values$user_file1 = values$user_file0
       values$boot_reps1 = values$boot_reps0
       values$boot_stat1 = values$boot_stat0
+      
+      # Navigate
+      updateTabsetPanel(session, "wizard", selected = "next_page")
     }
     else {
       # Show busy dialog
@@ -92,11 +95,11 @@ shinyServer(function(input, output, session) {
       )
       values$boot_reps1 = boot_results$reps
       values$boot_stat1 = boot_results$stat
+      
+      # Navigate to results
+      updateTabsetPanel(session, "wizard", selected = "outlier_results")
+      remove_modal_spinner()
     }
-    
-    # Navigate to results
-    updateTabsetPanel(session, "wizard", selected = "outlier_results")
-    remove_modal_spinner()
   })
   
   observeEvent(input$outliers_previous, {

--- a/server.R
+++ b/server.R
@@ -98,7 +98,7 @@ shinyServer(function(input, output, session) {
   })
   
   observeEvent(input$outliers_previous, {
-    updateTabsetPanel(session, "wizard", selected = "boot_results")
+    updateTabsetPanel(session, "wizard", selected = "prelim_results")
   })
   
   # Data ingest ================================================================

--- a/ui.R
+++ b/ui.R
@@ -100,7 +100,7 @@ shinyUI(fluidPage(
         
         # Outlier-removed results page =========================================
         tabPanelBody("outlier_results",
-          titlePanel("Results with Outliers Removed"),
+          titlePanel("Results with Selected Outliers Removed"),
           boot_results_ui("outliers")
         )
       )

--- a/ui.R
+++ b/ui.R
@@ -102,6 +102,11 @@ shinyUI(fluidPage(
         tabPanelBody("outlier_results",
           titlePanel("Results with Selected Outliers Removed"),
           boot_results_ui("outliers")
+        ),
+        
+        # Next page ============================================================
+        tabPanelBody("next_page",
+          
         )
       )
     )

--- a/ui.R
+++ b/ui.R
@@ -66,8 +66,8 @@ shinyUI(fluidPage(
           )
         ),
         
-        # Bootstrap results page ===============================================
-        tabPanelBody("boot_results",
+        # Preliminary results page =============================================
+        tabPanelBody("prelim_results",
           titlePanel("Preliminary Results"),
           boot_results_ui("prelim"),
           # Navigation ---------------------------------------------------------
@@ -81,6 +81,7 @@ shinyUI(fluidPage(
           )
         ),
         
+        # Outlier detection ====================================================
         tabPanelBody("outlier_detection",
           # Outlier detection controls -----------------------------------------
           titlePanel("Outliers"),
@@ -95,6 +96,12 @@ shinyUI(fluidPage(
               actionButton("outliers_next", "Next", width = "100%")
             )
           )
+        ),
+        
+        # Outlier-removed results page =========================================
+        tabPanelBody("outlier_results",
+          titlePanel("Results with Outliers Removed"),
+          boot_results_ui("outliers")
         )
       )
     )


### PR DESCRIPTION
This will add functionality to remove desired outliers detected by the jackknife-after-bootstrap procedure. If the user chooses to remove at least one outlier, the bootstrap estimates will be recomputed. Otherwise, the user is sent to the next diagnostic check.